### PR TITLE
Add cache for filtered images

### DIFF
--- a/workshop014-cache/.gitignore
+++ b/workshop014-cache/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .vscode
+storage/*

--- a/workshop014-cache/docker-compose.yml
+++ b/workshop014-cache/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   app:
     image: node:18.0.0
-    command: npm run dev
+    command: bash -c "npm install && npm run dev"
     working_dir: /app
     volumes:
       - .:/app

--- a/workshop014-cache/src/config.js
+++ b/workshop014-cache/src/config.js
@@ -1,7 +1,7 @@
 const { join } = require("path");
 
 const images = {
-  mimeType: "image/png",
+  mimeType: "image/jpeg",
   storagePath: join(__dirname, "..", "storage", "images"),
 };
 

--- a/workshop014-cache/src/server.js
+++ b/workshop014-cache/src/server.js
@@ -1,6 +1,7 @@
 const express = require("express");
 
 const setupImageProcessor = require("./setup/imageProcessor");
+const setupCache = require("./setup/cache");
 const router = require("./routes");
 
 const app = express();
@@ -12,5 +13,6 @@ const server = app.listen(process.env.PORT || 3000);
 app.locals.server = server;
 
 setupImageProcessor(app);
+setupCache(app);
 
 console.log("App ready and listening in port 3030.");

--- a/workshop014-cache/src/setup/cache.js
+++ b/workshop014-cache/src/setup/cache.js
@@ -1,0 +1,30 @@
+const { createClient } = require("redis");
+const { randomUUID } = require("crypto");
+const { images } = require("../config");
+const { join } = require("path");
+const { writeFile, readFile } = require("fs/promises");
+
+module.exports = function (app) {
+  const redis = createClient({ url: "redis://cache:6379/0" });
+  redis.connect().catch(console.error);
+
+  redis.on("error", console.error);
+
+  app.locals.cacheImage = async function ({ url, image }) {
+    const path = join(images.storagePath, randomUUID());
+
+    await writeFile(path, image);
+
+    await redis.set(`image:${url}`, path);
+  };
+
+  app.locals.getCachedImage = async function ({ url }) {
+    const path = await redis.get(`image:${url}`);
+
+    if (!path) return null;
+
+    const image = await readFile(path);
+
+    return image;
+  };
+};


### PR DESCRIPTION
Now images are stored after a filter is applied to them in order to prevent the rework of the same request using cache aside.

![image](https://user-images.githubusercontent.com/37005228/219049325-f34208b5-ee46-4007-a847-8928bc31b516.png)
